### PR TITLE
Implement basic ontology pipeline skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,11 @@ python3.11 -m venv .venv
 source .venv/bin/activate
 pip install rdflib spacy pandas PyMuPDF "langchain>=0.1"
 ```
+
+### Running Tests
+
+After installing dependencies, run the unit tests with `pytest`:
+
+```bash
+pytest -q
+```

--- a/context_agent/loaders/document_loader.py
+++ b/context_agent/loaders/document_loader.py
@@ -1,6 +1,36 @@
-"""Document loader placeholder module."""
+"""Document loader supporting multiple formats."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List
+import xml.etree.ElementTree as ET
+
+import fitz  # PyMuPDF
+import pandas as pd
 
 
-def load_document(path: str) -> None:
-    """Placeholder function to load a document from ``path``."""
-    pass
+def load_document(path: str) -> List[str]:
+    """Load a document from ``path`` and return text chunks."""
+    ext = Path(path).suffix.lower()
+    if ext == ".pdf":
+        doc = fitz.open(path)
+        return [page.get_text() for page in doc]
+    if ext in {".xlsx", ".xls"}:
+        df = pd.read_excel(path, header=None)
+        return df.fillna("").astype(str).agg(" ".join, axis=1).tolist()
+    if ext == ".json":
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return [json.dumps(data)]
+    if ext == ".xml":
+        tree = ET.parse(path)
+        root = tree.getroot()
+        text = ET.tostring(root, encoding="unicode")
+        return [text]
+    if ext == ".ttl":
+        with open(path, "r", encoding="utf-8") as f:
+            return [f.read()]
+    with open(path, "r", encoding="utf-8") as f:
+        return [f.read()]

--- a/context_agent/loaders/ontology_loader.py
+++ b/context_agent/loaders/ontology_loader.py
@@ -1,6 +1,16 @@
-"""Ontology loader placeholder module."""
+"""Simple ontology loader using rdflib."""
+
+from __future__ import annotations
+
+from rdflib import Graph, RDFS
+from typing import Dict
 
 
-def load_ontology(path: str) -> None:
-    """Placeholder function to load an ontology from ``path``."""
-    pass
+def load_ontology(path: str) -> Dict[str, str]:
+    """Parse a TTL ontology file and return a label to URI lookup."""
+    graph = Graph()
+    graph.parse(path, format="ttl")
+    lookup: Dict[str, str] = {}
+    for subject, _, label in graph.triples((None, RDFS.label, None)):
+        lookup[str(label).lower()] = str(subject)
+    return lookup

--- a/context_agent/processors/langchain_agent.py
+++ b/context_agent/processors/langchain_agent.py
@@ -1,6 +1,24 @@
-"""LangChain agent placeholder module."""
+"""Minimal LangChain agent stub."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from langchain.llms.base import LLM
 
 
-def run_agent(query: str) -> None:
-    """Placeholder function to run the LangChain agent with ``query``."""
-    pass
+class DummyLLM(LLM):
+    """LLM stub used when no real model is provided."""
+
+    @property
+    def _llm_type(self) -> str:  # pragma: no cover - simple property
+        return "dummy"
+
+    def _call(self, prompt: str, stop: Optional[list[str]] = None) -> str:
+        return "stub"
+
+
+def run_agent(query: str, llm: Optional[LLM] = None) -> str:
+    """Run the LangChain agent with ``query`` using ``llm``."""
+    llm = llm or DummyLLM()
+    return llm(query)

--- a/context_agent/processors/ner_matcher.py
+++ b/context_agent/processors/ner_matcher.py
@@ -1,6 +1,24 @@
-"""NER matcher placeholder module."""
+"""Entity matcher using spaCy and ontology labels."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Tuple
+
+import spacy
+
+_nlp = spacy.blank("en")
 
 
-def match_entities(text: str) -> None:
-    """Placeholder function to match entities in ``text``."""
-    pass
+def match_entities(texts: Iterable[str], ontology: Dict[str, str]) -> List[Tuple[str, str]]:
+    """Match ontology labels appearing in ``texts``.
+
+    Returns a list of ``(label, uri)`` tuples.
+    """
+    matches: List[Tuple[str, str]] = []
+    for text in texts:
+        _nlp(text)  # tokenization side effect
+        lower_text = text.lower()
+        for label, uri in ontology.items():
+            if label in lower_text:
+                matches.append((label, uri))
+    return matches

--- a/context_agent/writers/csv_writer.py
+++ b/context_agent/writers/csv_writer.py
@@ -1,6 +1,13 @@
-"""CSV writer placeholder module."""
+"""CSV writer using Python's csv module."""
+
+from __future__ import annotations
+
+import csv
+from typing import Iterable, Sequence
 
 
-def write_csv(data: object, path: str) -> None:
-    """Placeholder function to write CSV ``data`` to ``path``."""
-    pass
+def write_csv(rows: Iterable[Sequence[str]], path: str) -> None:
+    """Write ``rows`` to ``path`` as CSV."""
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerows(rows)

--- a/context_agent/writers/ttl_writer.py
+++ b/context_agent/writers/ttl_writer.py
@@ -1,6 +1,15 @@
-"""TTL writer placeholder module."""
+"""TTL writer using rdflib."""
+
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+from rdflib import Graph, URIRef
 
 
-def write_ttl(data: object, path: str) -> None:
-    """Placeholder function to write TTL ``data`` to ``path``."""
-    pass
+def write_ttl(triples: Iterable[Tuple[str, str, str]], path: str) -> None:
+    """Write ``triples`` to ``path`` in Turtle format."""
+    graph = Graph()
+    for s, p, o in triples:
+        graph.add((URIRef(s), URIRef(p), URIRef(o)))
+    graph.serialize(destination=path, format="ttl")

--- a/tests/fixtures/gistCyber.ttl
+++ b/tests/fixtures/gistCyber.ttl
@@ -1,0 +1,5 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex: <http://example.com/> .
+
+ex:Control a rdfs:Class ;
+    rdfs:label "Control" .

--- a/tests/fixtures/sample.json
+++ b/tests/fixtures/sample.json
@@ -1,0 +1,1 @@
+{"control": "Implement multi-factor authentication"}

--- a/tests/fixtures/sample.xml
+++ b/tests/fixtures/sample.xml
@@ -1,0 +1,3 @@
+<root>
+    <control>Implement MFA</control>
+</root>

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,23 @@
+import os
+from context_agent.loaders.ontology_loader import load_ontology
+from context_agent.loaders.document_loader import load_document
+
+FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+def test_load_ontology():
+    path = os.path.join(FIXTURES, 'gistCyber.ttl')
+    ontology = load_ontology(path)
+    assert 'control' in ontology
+
+
+def test_load_document_json():
+    path = os.path.join(FIXTURES, 'sample.json')
+    docs = load_document(path)
+    assert isinstance(docs, list) and docs
+
+
+def test_load_document_xml():
+    path = os.path.join(FIXTURES, 'sample.xml')
+    docs = load_document(path)
+    assert isinstance(docs, list) and docs

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -1,0 +1,8 @@
+from context_agent.processors.ner_matcher import match_entities
+
+
+def test_match_entities():
+    ontology = {'control': 'http://example.com/Control'}
+    texts = ['This control enforces security.']
+    matches = match_entities(texts, ontology)
+    assert ('control', 'http://example.com/Control') in matches

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,0 +1,19 @@
+import os
+from context_agent.writers.csv_writer import write_csv
+from context_agent.writers.ttl_writer import write_ttl
+
+
+def test_write_csv(tmp_path):
+    out = tmp_path / 'out.csv'
+    write_csv([["a", "b"], ["c", "d"]], out)
+    assert out.read_text().startswith('a,b')
+
+
+def test_write_ttl(tmp_path):
+    out = tmp_path / 'out.ttl'
+    triples = [(
+        'http://example.com/s',
+        'http://example.com/p',
+        'http://example.com/o')]
+    write_ttl(triples, out)
+    assert out.exists() and out.read_text()


### PR DESCRIPTION
## Summary
- flesh out module placeholders for ontology loader, document loader, NER matcher, LangChain agent, and writers
- add simple unit tests and fixtures
- update README with test instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rdflib')*

------
https://chatgpt.com/codex/tasks/task_e_685d4faf98ec8325897cd434913f7a1c