### PR TITLE
Improve ontology vector search and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository implements an ontology-aware context ingestion pipeline for cybe
 - **NER matcher** – identifies concepts in documents using `spacy` and ontology mappings.
 - **LangChain agent** – orchestrates ontology lookups, document queries, and reasoning.
 - **Output writers** – serialize results to desired formats for analysis or storage.
+- **Ontology vector lookup** – performs semantic similarity search over ontology labels using spaCy vectors.
 
 ## Setup
 1. Install Python 3.11.
@@ -25,4 +26,12 @@ After installing dependencies, run the unit tests with `pytest`:
 
 ```bash
 pytest -q
+```
+
+### Ontology Vector Lookup Demo
+
+Run a semantic search over an ontology file:
+
+```bash
+python -m context_agent.tools.ontology_vector_lookup path/to/ontology.ttl "your query" -n 5
 ```

--- a/context_agent/tools/__init__.py
+++ b/context_agent/tools/__init__.py
@@ -1,0 +1,16 @@
+"""Tooling utilities for context_agent."""
+
+from __future__ import annotations
+
+from .ontology_vector_lookup import (
+    OntologyVectorLookup,
+    init_lookup,
+    search_ontology,
+)
+
+__all__ = [
+    "OntologyVectorLookup",
+    "init_lookup",
+    "search_ontology",
+]
+

--- a/context_agent/tools/ontology_vector_lookup.py
+++ b/context_agent/tools/ontology_vector_lookup.py
@@ -1,0 +1,76 @@
+"""Ontology label vector lookup using spaCy."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, List, Tuple
+
+import numpy as np
+import spacy
+from rdflib import Graph, RDFS
+
+
+class OntologyVectorLookup:
+    """Load ontology labels and enable semantic search."""
+
+    def __init__(self, path: str):
+        self.graph = Graph()
+        self.graph.parse(path, format="ttl")
+        self.labels: List[str] = []
+        self.uris: List[str] = []
+        for subject, _, label in self.graph.triples((None, RDFS.label, None)):
+            self.labels.append(str(label))
+            self.uris.append(str(subject))
+        self.nlp = spacy.load("en_core_web_lg")
+        # Precompute label vectors for efficiency using nlp.pipe
+        docs = list(self.nlp.pipe(self.labels))
+        self.label_vectors = np.stack([doc.vector for doc in docs]) if docs else np.empty((0, 0))
+        self.label_norms = np.linalg.norm(self.label_vectors, axis=1) if docs else np.empty(0)
+
+    def search(self, query: str, top_n: int = 3) -> List[Tuple[str, str, float]]:
+        """Return top ``top_n`` labels most similar to ``query``."""
+        if not self.labels:
+            return []
+        q_vec = self.nlp(query).vector
+        q_norm = np.linalg.norm(q_vec)
+        if q_norm == 0:
+            return []
+        sims = self.label_vectors @ q_vec / (self.label_norms * q_norm + 1e-8)
+        idxs = np.argsort(-sims)[:top_n]
+        return [
+            (self.labels[i], self.uris[i], float(sims[i]))
+            for i in idxs
+        ]
+
+
+_lookup: OntologyVectorLookup | None = None
+
+
+def init_lookup(path: str) -> None:
+    """Initialize global lookup instance from ``path``."""
+    global _lookup
+    _lookup = OntologyVectorLookup(path)
+
+
+def search_ontology(query: str, top_n: int = 3) -> List[Tuple[str, str, float]]:
+    """Search initialized ontology for ``query`` and return matches."""
+    if _lookup is None:
+        raise RuntimeError("OntologyVectorLookup is not initialized")
+    return _lookup.search(query, top_n)
+
+
+def _cli(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Ontology semantic search")
+    parser.add_argument("ontology", help="Path to ontology TTL file")
+    parser.add_argument("query", help="Search query")
+    parser.add_argument("-n", "--top-n", type=int, default=3)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    init_lookup(args.ontology)
+    for label, uri, score in search_ontology(args.query, args.top_n):
+        print(f"{label}\t{uri}\t{score:.3f}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage
+    raise SystemExit(_cli())

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,38 @@
+import os
+import types
+import pytest
+
+spacy = pytest.importorskip("spacy")
+pytest.importorskip("rdflib")
+pytest.importorskip("numpy")
+
+from context_agent.tools.ontology_vector_lookup import OntologyVectorLookup
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+class DummyDoc:
+    def __init__(self, text: str) -> None:
+        self.vector = [1.0] if text.lower() == "control" else [0.0]
+
+
+class DummyNLP:
+    def __call__(self, text: str) -> DummyDoc:  # type: ignore[override]
+        return DummyDoc(text)
+
+    def pipe(self, texts):
+        for t in texts:
+            yield DummyDoc(t)
+
+
+def test_vector_lookup(monkeypatch):
+    monkeypatch.setattr("spacy.load", lambda _: DummyNLP())
+    path = os.path.join(FIXTURES, "gistCyber.ttl")
+    lookup = OntologyVectorLookup(path)
+    results = lookup.search("control", top_n=1)
+    assert results
+    label, uri, score = results[0]
+    assert label.lower() == "control"
+    assert uri
+    assert score >= 0.0
+


### PR DESCRIPTION
## Summary
- expose ontology vector functions from tools package
- precompute label vectors via `nlp.pipe`
- add unit test for semantic search

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rdflib')*

------
https://chatgpt.com/codex/tasks/task_e_685d63c9a3bc832593fa6bc21edde071