### PR TITLE
Add document processing pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ Run a semantic search over an ontology file:
 ```bash
 python -m context_agent.tools.ontology_vector_lookup path/to/ontology.ttl "your query" -n 5
 ```
+
+### Simple Ingestion Example
+
+Process a set of documents using one or more ontologies and write the results to a TTL file:
+
+```bash
+python -m context_agent.tools.process_documents \
+    -o path/to/onto1.ttl -o path/to/onto2.ttl \
+    -d docs/report.pdf -d controls.xlsx \
+    output.ttl
+```

--- a/context_agent/loaders/ontology_loader.py
+++ b/context_agent/loaders/ontology_loader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from rdflib import Graph, RDFS
-from typing import Dict
+from typing import Dict, Iterable
 
 
 def load_ontology(path: str) -> Dict[str, str]:
@@ -14,3 +14,11 @@ def load_ontology(path: str) -> Dict[str, str]:
     for subject, _, label in graph.triples((None, RDFS.label, None)):
         lookup[str(label).lower()] = str(subject)
     return lookup
+
+
+def load_ontologies(paths: Iterable[str]) -> Dict[str, str]:
+    """Load and merge multiple ontology files into a single lookup."""
+    merged: Dict[str, str] = {}
+    for path in paths:
+        merged.update(load_ontology(path))
+    return merged

--- a/context_agent/tools/__init__.py
+++ b/context_agent/tools/__init__.py
@@ -7,10 +7,12 @@ from .ontology_vector_lookup import (
     init_lookup,
     search_ontology,
 )
+from .process_documents import process
 
 __all__ = [
     "OntologyVectorLookup",
     "init_lookup",
     "search_ontology",
+    "process",
 ]
 

--- a/context_agent/tools/process_documents.py
+++ b/context_agent/tools/process_documents.py
@@ -1,0 +1,53 @@
+"""Simple pipeline for processing documents with an ontology."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable
+
+from ..loaders.ontology_loader import load_ontologies
+from ..loaders.document_loader import load_document
+from ..processors.ner_matcher import match_entities
+from ..writers.ttl_writer import write_ttl
+
+
+def process(ontology_paths: Iterable[str], docs: Iterable[str], out_path: str) -> None:
+    """Load ``ontology_paths`` and ``docs`` then write matches to ``out_path``."""
+    ontology = load_ontologies(ontology_paths)
+    texts: list[str] = []
+    for path in docs:
+        texts.extend(load_document(path))
+    matches = match_entities(texts, ontology)
+    triples = [
+        (f"http://example.com/match/{i}", "http://example.com/entity", uri)
+        for i, (_, uri) in enumerate(matches)
+    ]
+    write_ttl(triples, out_path)
+
+
+def _cli(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Process documents and output TTL")
+    parser.add_argument("output", help="Path to output TTL file")
+    parser.add_argument(
+        "-o",
+        "--ontology",
+        action="append",
+        required=True,
+        dest="ontologies",
+        help="Ontology TTL file (repeat for multiple)",
+    )
+    parser.add_argument(
+        "-d",
+        "--document",
+        action="append",
+        required=True,
+        dest="documents",
+        help="Document to process (repeat for multiple)",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    process(args.ontologies, args.documents, args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    raise SystemExit(_cli())

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,5 @@
 import os
-from context_agent.loaders.ontology_loader import load_ontology
+from context_agent.loaders.ontology_loader import load_ontology, load_ontologies
 from context_agent.loaders.document_loader import load_document
 
 FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -9,6 +9,12 @@ def test_load_ontology():
     path = os.path.join(FIXTURES, 'gistCyber.ttl')
     ontology = load_ontology(path)
     assert 'control' in ontology
+
+
+def test_load_ontologies():
+    path = os.path.join(FIXTURES, 'gistCyber.ttl')
+    ontology = load_ontologies([path, path])
+    assert 'control' in ontology and len(ontology) >= 1
 
 
 def test_load_document_json():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,12 @@
+import os
+from context_agent.tools.process_documents import process
+
+FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
+
+
+def test_process(tmp_path):
+    ontology = os.path.join(FIXTURES, "gistCyber.ttl")
+    doc = os.path.join(FIXTURES, "sample.json")
+    out = tmp_path / "out.ttl"
+    process([ontology], [doc], out)
+    assert out.exists() and out.read_text()


### PR DESCRIPTION
## Summary
- add a simple `process_documents` tool to load an ontology and documents
- expose the new `process` function via `context_agent.tools`
- document usage in README
- add unit test for the processing function
- allow multiple ontology files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rdflib')*

------
https://chatgpt.com/codex/tasks/task_e_685d6718426c8325b261fca4a466bd9e