### PR TITLE
Simplify control loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,19 @@ This approach works well for enumerated lists of controls or attack steps
 found in spreadsheets or JSON files.  Each row or object in the file is
 converted to text and compared with the ontology so that related concepts
 are linked in the resulting TTL.
+
+### Control Agent CLI
+
+The `context_agent.tools.control_agent` module exposes a command-line
+interface that ingests any number of documents and prints a spaCy token
+stream for inspection.  When ontology files and an output path are
+provided, TTL triples are also generated.
+
+```bash
+python -m context_agent.tools.control_agent \
+    path/to/catalog.json controls.xlsx other.pdf \
+    -o path/to/ontology.ttl -t output.ttl
+```
+
+The command prints the tokenized representation to standard output,
+which can help diagnose how the text will be fed into an LLM.

--- a/context_agent/__init__.py
+++ b/context_agent/__init__.py
@@ -1,0 +1,9 @@
+"""Context Agent package."""
+
+from .processors.spacy_processor import tokenize_texts
+from .tools.control_agent import process_controls
+
+__all__ = [
+    "tokenize_texts",
+    "process_controls",
+]

--- a/context_agent/processors/spacy_processor.py
+++ b/context_agent/processors/spacy_processor.py
@@ -1,0 +1,18 @@
+"""Utilities for processing text with spaCy."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+import spacy
+
+_nlp = None
+
+
+def tokenize_texts(texts: Iterable[str]) -> List[List[str]]:
+    """Return tokenized versions of ``texts`` using spaCy."""
+    global _nlp
+    if _nlp is None:
+        _nlp = spacy.blank("en")
+    docs = _nlp.pipe(texts)
+    return [[token.text for token in doc] for doc in docs]

--- a/context_agent/tools/control_agent.py
+++ b/context_agent/tools/control_agent.py
@@ -1,0 +1,71 @@
+"""Process control data and run a LangChain agent."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, List, Optional
+
+from ..loaders.document_loader import load_document
+from ..loaders.ontology_loader import load_ontologies
+from ..processors.spacy_processor import tokenize_texts
+from ..processors.ner_matcher import match_entities
+from ..processors.langchain_agent import run_agent, DummyLLM
+
+
+_DEFAULT_LLM = DummyLLM()
+
+
+def process_controls(
+    docs: Iterable[str] | None = None,
+    ontology_files: Iterable[str] | None = None,
+    output_ttl: str | None = None,
+    llm: Optional[DummyLLM] = None,
+) -> List[List[str]]:
+    """Load data from ``docs`` and generate TTL using an LLM."""
+    llm = llm or _DEFAULT_LLM
+    texts: List[str] = []
+    if docs:
+        for path in docs:
+            texts.extend(load_document(path))
+
+    tokens = tokenize_texts(texts)
+
+    ontology = load_ontologies(ontology_files) if ontology_files else {}
+    annotations = match_entities(texts, ontology) if ontology else []
+
+    if output_ttl and ontology_files:
+        ttl_chunks: List[str] = []
+        for text in texts:
+            prompt = (
+                f"DATA:\n{text}\nANNOTATIONS:{annotations}\n\n"
+                f"Use the ontology and annotations to create TTL triples."
+            )
+            ttl_chunks.append(run_agent(prompt, llm=llm))
+        with open(output_ttl, "w", encoding="utf-8") as f:
+            f.write("\n".join(ttl_chunks))
+
+    # Run the agent for side effects (e.g., reasoning) over tokenized content
+    for toks in tokens:
+        run_agent(" ".join(toks), llm=llm)
+
+    return tokens
+
+
+def _cli(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Process documents with LangChain")
+    parser.add_argument("docs", nargs="+", help="Input documents")
+    parser.add_argument("-o", "--ontology", action="append", dest="ontology_files")
+    parser.add_argument("-t", "--ttl", dest="output_ttl")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    tokens = process_controls(
+        docs=args.docs,
+        ontology_files=args.ontology_files,
+        output_ttl=args.output_ttl,
+    )
+    for tok_list in tokens:
+        print(" ".join(tok_list))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    raise SystemExit(_cli())

--- a/tests/fixtures/nist_catalog.json
+++ b/tests/fixtures/nist_catalog.json
@@ -1,0 +1,14 @@
+{
+  "catalog": {
+    "controls": [
+      {
+        "id": "ac-1",
+        "title": "Access Control Policy and Procedures"
+      },
+      {
+        "id": "ac-2",
+        "title": "Account Management"
+      }
+    ]
+  }
+}

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -31,3 +31,8 @@ def test_load_document_xml():
     path = os.path.join(FIXTURES, 'sample.xml')
     docs = load_document(path)
     assert isinstance(docs, list) and docs
+
+def test_load_document_nist_catalog():
+    path = os.path.join(FIXTURES, 'nist_catalog.json')
+    docs = load_document(path)
+    assert isinstance(docs, list) and docs

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,6 +7,7 @@ pytest.importorskip("rdflib")
 pytest.importorskip("numpy")
 
 from context_agent.tools.ontology_vector_lookup import OntologyVectorLookup
+from langchain.llms.base import LLM
 
 FIXTURES = os.path.join(os.path.dirname(__file__), "fixtures")
 
@@ -36,3 +37,43 @@ def test_vector_lookup(monkeypatch):
     assert uri
     assert score >= 0.0
 
+
+from context_agent.tools.control_agent import process_controls
+
+
+def test_process_controls(monkeypatch, tmp_path):
+    # Use dummy spaCy to speed up tests
+    class DummyToken:
+        def __init__(self, text):
+            self.text = text
+
+    class DummyDoc(list):
+        def __init__(self, text):
+            super().__init__([DummyToken(t) for t in text.split()])
+
+    class DummyNLP:
+        def __call__(self, text):
+            return DummyDoc(text)
+
+        def pipe(self, texts):
+            for t in texts:
+                yield DummyDoc(t)
+
+    class DummyLLM(LLM):
+        @property
+        def _llm_type(self) -> str:
+            return "dummy"
+
+        def _call(self, prompt: str, stop: list[str] | None = None) -> str:
+            return "@prefix ex: <http://example.com/> . ex:s ex:p ex:o ."
+
+    monkeypatch.setattr("spacy.blank", lambda _: DummyNLP())
+    out = tmp_path / "out.ttl"
+    tokens = process_controls(
+        docs=[os.path.join(FIXTURES, "nist_catalog.json")],
+        ontology_files=[os.path.join(FIXTURES, "gistCyber.ttl")],
+        output_ttl=str(out),
+        llm=DummyLLM(),
+    )
+    assert tokens
+    assert out.exists() and out.read_text()


### PR DESCRIPTION
## Summary
- remove `control_loader` in favor of `document_loader`
- simplify `process_controls` to accept any document list
- update CLI and README
- adjust tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9b432a7c832588c63300ce480a81